### PR TITLE
Fix spectating entities not working, viewing a SecurityCraft security camera not being possible, and more

### DIFF
--- a/src/main/java/com/windanesz/ancientspellcraft/client/ClientEventHandler.java
+++ b/src/main/java/com/windanesz/ancientspellcraft/client/ClientEventHandler.java
@@ -63,7 +63,7 @@ public class ClientEventHandler {
 				previousZ = z;
 				previousPitch = Minecraft.getMinecraft().player.rotationPitch;
 				pirevousYaw = Minecraft.getMinecraft().player.rotationYaw;
-			} else {
+			} else if (Minecraft.getMinecraft().getRenderViewEntity() == ASFakePlayer.FAKE_PLAYER) {
 				Minecraft.getMinecraft().setRenderViewEntity(Minecraft.getMinecraft().player);
 			}
 


### PR DESCRIPTION
The following lines of code cause issues in the default game (spectating entities) and also in other mods (example below). These are due to the following line, which, if neither eagle eye nor astral travel are enabled, just resets the player's render view entity back to the player entity, disregarding the previous render view entity.
https://github.com/WinDanesz/AncientSpellcraft/blob/9b64f30edd89d1d2196a64d365fd262e630455c1/src/main/java/com/windanesz/ancientspellcraft/client/ClientEventHandler.java#L66-L68

I am assuming this line exists so that once the above mentioned effects wear off, the player returns to their own body. However because of the lack of a check for the previous entity, any time anything sets the render view entity to something else, Ancient Spellcraft will just reset it back to the client player, meaning nothing but this mod can change it. This pull request fixes that, by adding a check prior to the statement, which - given both effects are inactive - checks if the render view entity is the mod's fake player. If that is the case, the render view entity will be reset. In all other cases, including when no effect is active, the render view entity will just be kept at whatever it is at that point in time.

An example of a mod breaking: [SecurityCraft](https://www.curseforge.com/minecraft/mc-mods/security-craft). It adds security cameras, which the player can bind to a camera monitor and view through their own eyes. This is achieved by spawning an entity at the camera's position, and then changing the render view entity to that newly spawned entity.  As soon as the player is viewing the camera, the render view entity is reset by this mod, stopping the player from viewing the camera.

From what I can tell, issues #72 and #73 will be fixed by merging this pull request, too.